### PR TITLE
Only use debug in watch mode, use uglifyify in build step. Closes #181

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,7 +67,9 @@ gulp.task('clean', function (cb) {
 * Build scripts and optionally watch for changes
 */
 function scripts (src, dest, watch) {
-  var bundleOpts = _.extend({}, watchify.args, {debug: true})
+  var bundleOpts = _.extend({}, watchify.args)
+  if (watch) bundleOpts.debug = true
+
   var bundle = browserify(src, bundleOpts)
 
   if (watch) {
@@ -75,6 +77,8 @@ function scripts (src, dest, watch) {
 
     bundle.on('update', function () { compileBundle(bundle, dest) }) // when a dependency changes, recompile
     bundle.on('log', gutil.log) // output build logs to terminal
+  } else {
+    bundle.transform({ global: true }, 'uglifyify')
   }
 
   return compileBundle(bundle, dest)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0",
     "tape-run": "^2.1.1",
+    "uglifyify": "^3.0.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.3.1"


### PR DESCRIPTION
Got it from `1.5MB` down to `866KB`. Could probably get further by passing it to uglify and gzipping it, but this is at least an improvement. Ran discify and found datatables and amcharts to be the largest culprits...